### PR TITLE
ensure config file generation is idempotent on rubies > 1.8.7 and genera...

### DIFF
--- a/templates/config.json.erb
+++ b/templates/config.json.erb
@@ -1,3 +1,3 @@
 <%- require 'json' -%>
 <%- @config_hash.has_key?("protocol") and @config_hash["protocol"] = @config_hash["protocol"].to_i -%>
-<%= @config_hash.to_json %>
+<%= JSON.pretty_generate(Hash[@config_hash.sort]) %>


### PR DESCRIPTION
This change will produce an idempotent config file when using rubies > 1.8.7. Hash order is preserved in 1.9.3 but not in 1.8.7 so the config will still drift when using older rubies. If you want to support 1.8.7 it will be necessary to write a custom function for the puppet parser to generate ordered JSON. One example for this approach can be found in this gist:

https://gist.github.com/halkeye/2287885
