### PR TITLE
remove unused $conf_dir param

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,6 @@
 class serf (
   $version              = '0.4.1',
   $bin_dir              = '/usr/local/bin',
-  $conf_dir             = '/etc/serf',
   $handlers_dir         = '/etc/serf/handlers',
   $arch                 = $serf::params::arch,
   $init_script_url      = $serf::params::init_script_url,


### PR DESCRIPTION
since you are using the hashicorp supplied init script which hard codes the serf configuration directory, the $conf_dir param is non-functional. you could always pull down the init scripts and create templates from them but i'm not sure how far down that rabbit hole you want to go.
