### PR TITLE
Update location to sys init scripts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,11 +15,11 @@ class serf::params {
 
   case $::osfamily {
     'redhat': {
-      $init_script_url      = 'https://raw.github.com/hashicorp/serf/master/ops-misc/serf.sysv.init'
+      $init_script_url      = 'https://raw.githubusercontent.com/hashicorp/serf/master/ops-misc/serf.sysv.init'
       $init_script_path     = '/etc/init.d/serf'
     }
     'debian': {
-      $init_script_url      = 'https://raw.github.com/hashicorp/serf/master/ops-misc/upstart.conf'
+      $init_script_url      = 'https://raw.githubusercontent.com/hashicorp/serf/master/ops-misc/debian/serf.upstart'
       $init_script_path     = '/etc/init/serf.conf'
     }
     default: { fail("Unsupported OS family \"${::osfamily}\". Module only supports redhat and debian. Serf supports others, but module is untested.") }


### PR DESCRIPTION
The raw.github.com url returns a redirect and won't work in some automation tools.

``` sh:
$ curl -ik https://raw.github.com/hashicorp/serf/master/ops-misc/serf.sysv.init
HTTP/1.1 301 Moved Permanently
Date: Fri, 22 Aug 2014 14:36:46 GMT
Server: Apache
Location: https://raw.githubusercontent.com/hashicorp/serf/master/ops-misc/serf.sysv.init
Content-Length: 0
```
